### PR TITLE
fix: resolve Sentry v10 configuration and build warning

### DIFF
--- a/config/next.config.mjs
+++ b/config/next.config.mjs
@@ -50,11 +50,7 @@ if (shouldUseSentry && hasSentryConfig) {
     // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
     tunnelRoute: '/monitoring',
 
-    // Automatically tree-shake Sentry logger statements to reduce bundle size
-    disableLogger: true,
 
-    // Enables automatic instrumentation of Vercel Cron Monitors.
-    automaticVercelMonitors: true,
 
     // Source map configuration using newer options
     sourcemaps: {
@@ -78,6 +74,14 @@ if (shouldUseSentry && hasSentryConfig) {
       }
       return config
     },
+
+    // Automatically tree-shake Sentry logger statements to reduce bundle size
+    treeshake: {
+      removeDebugLogging: true,
+    },
+
+    // Enables automatic instrumentation of Vercel Cron Monitors
+    automaticVercelMonitors: true,
   })
 } else {
   console.warn('Sentry configuration incomplete - building without Sentry source map upload')

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "cross-env NODE_OPTIONS=--no-deprecation next build",
+    "build": "cross-env NODE_ENV=production NODE_OPTIONS=--no-deprecation next build",
     "postbuild": "next-sitemap --config next-sitemap.config.cjs",
     "ci": "cross-env NODE_OPTIONS=--no-deprecation bun run build",
     "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev --turbopack",

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -11,8 +11,8 @@ Sentry.init({
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
 
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
+  // Add the console logging integration
+  integrations: [Sentry.consoleLoggingIntegration({ levels: ['log', 'error', 'warn', 'info', 'debug'] })],
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -13,8 +13,8 @@ Sentry.init({
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
 
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
+  // Add the console logging integration
+  integrations: [Sentry.consoleLoggingIntegration({ levels: ['log', 'error', 'warn', 'info', 'debug'] })],
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -20,10 +20,7 @@ Sentry.init({
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1.0,
 
-  // Enable logs to be sent to Sentry
-  _experiments: {
-    enableLogs: true,
-  },
+
 
   // Define how likely Replay events are sampled.
   // This sets the sample rate to be 10%. You may want this to be 100% while
@@ -37,4 +34,3 @@ Sentry.init({
   debug: false,
 })
 
-export const onRouterTransitionStart = Sentry.captureRouterTransitionStart

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -34,3 +34,5 @@ Sentry.init({
   debug: false,
 })
 
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart
+

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -12,5 +12,5 @@ export async function register() {
 
 export const onRequestError = async (err: Error, request: Request, context: unknown) => {
   const Sentry = await import('@sentry/nextjs')
-  Sentry.captureRequestError(err, request, context)
+  Sentry.captureRequestError(err, request as any, context)
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/nextjs'
+
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
@@ -8,4 +8,9 @@ export async function register() {
   if (process.env.NEXT_RUNTIME === 'edge') {
     await import('../sentry.edge.config')
   }
+}
+
+export const onRequestError = async (err: any, request: any, context: any) => {
+  const Sentry = await import('@sentry/nextjs')
+  Sentry.captureRequestError(err, request, context)
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -12,5 +12,5 @@ export async function register() {
 
 export const onRequestError = async (err: Error, request: Request, context: unknown) => {
   const Sentry = await import('@sentry/nextjs')
-  Sentry.captureRequestError(err, request as any, context)
+  Sentry.captureRequestError(err, request as any, context as any)
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -10,7 +10,7 @@ export async function register() {
   }
 }
 
-export const onRequestError = async (err: any, request: any, context: any) => {
+export const onRequestError = async (err: Error, request: Request, context: unknown) => {
   const Sentry = await import('@sentry/nextjs')
   Sentry.captureRequestError(err, request, context)
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -9,5 +9,3 @@ export async function register() {
     await import('../sentry.edge.config')
   }
 }
-
-export const onRequestError = Sentry.captureRequestError


### PR DESCRIPTION
## Description
PR #11 was merged before these fixes were applied. This PR addresses the critical Sentry v10 configuration issues and NODE_ENV warning.

## Changes
- Restore required Sentry v10 hooks: `onRequestError` and `onRouterTransitionStart`
- Fix TypeScript errors in `onRequestError`
- Remove unused Sentry import in `instrumentation.ts`
- Set explicit `NODE_ENV=production` in build script
- Update `next.config.mjs` and Sentry config files to remove deprecated options

## Verification
- Build verified locally (NODE_ENV warning gone)
- Sentry hooks verified