### PR TITLE
Security Update: Node.js January 2026 Release (v22.22.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # To use this Dockerfile, you have to set `output: 'standalone'` in your next.config.js file.
 # From https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
 
-FROM node:22.12.0-alpine AS base
+FROM node:22.22.0-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "packageManager": "bun@1.2.19",
   "engines": {
-    "node": "22",
+    "node": ">=22.22.0",
     "bun": ">=1.2.0"
   },
   "trustedDependencies": [


### PR DESCRIPTION
This PR merges the security updates from development/preview into main.
Includes fixes for:
- CVE-2025-55131
- CVE-2025-55130
- CVE-2025-59465
And updates Node.js to v22.22.0.